### PR TITLE
replaced sysout loggin by logback loggers

### DIFF
--- a/backend/src/main/java/de/ultical/backend/api/TeamResource.java
+++ b/backend/src/main/java/de/ultical/backend/api/TeamResource.java
@@ -17,6 +17,8 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response.Status;
 
 import org.apache.ibatis.exceptions.PersistenceException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import de.ultical.backend.app.Authenticator;
 import de.ultical.backend.data.DataStore;
@@ -27,6 +29,8 @@ import io.dropwizard.auth.Auth;
 
 @Path("/teams")
 public class TeamResource {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TeamResource.class);
 
     @Inject
     DataStore dataStore;
@@ -130,10 +134,9 @@ public class TeamResource {
                 try {
                     this.dataStore.addAdminToTeam(newTeam, admin);
                 } catch (Exception e) {
-                    System.out.println("Error adding Admin:");
-                    System.out.println("Team: " + newTeam.getName() + " (" + newTeam.getId() + ")");
-                    System.out.println("User: " + admin.getFullName() + " (" + admin.getId() + ")");
-                    System.out.println(e.getMessage());
+                    LOGGER.error("Error adding Admin:\nTeam: {} ( {} )\nUser: {} ( {} )", newTeam.getName(),
+                            newTeam.getId(), admin.getFullName(), admin.getId());
+                    LOGGER.error("exception:", e);
                 }
             }
 
@@ -203,10 +206,10 @@ public class TeamResource {
                 try {
                     this.dataStore.addAdminToTeam(updatedTeam, admin);
                 } catch (Exception e) {
-                    System.out.println("Error updating Admin:");
-                    System.out.println("Team: " + updatedTeam.getName() + " (" + updatedTeam.getId() + ")");
-                    System.out.println("User: " + admin.getFullName() + " (" + admin.getId() + ")");
-                    System.out.println(e.getMessage());
+                    LOGGER.error("Error adding Admin:\nTeam: {} ( {} )\nUser: {} ( {} )\ncurrentUser: {}",
+                            updatedTeam.getName(), updatedTeam.getId(), admin.getFullName(), admin.getId(),
+                            currentUser.getId());
+                    LOGGER.error("exception:", e);
                 }
             }
         }

--- a/backend/src/main/java/de/ultical/backend/app/Application.java
+++ b/backend/src/main/java/de/ultical/backend/app/Application.java
@@ -32,6 +32,7 @@ import de.ultical.backend.api.TeamResource;
 import de.ultical.backend.api.TournamentFormatResource;
 import de.ultical.backend.api.TournamentResource;
 import de.ultical.backend.api.UserResource;
+import de.ultical.backend.app.logging.UlticalLoggingFilter;
 import de.ultical.backend.data.DataStore;
 import de.ultical.backend.data.LocalDateMixIn;
 import de.ultical.backend.data.mapper.UserMapper;
@@ -154,6 +155,8 @@ public class Application extends io.dropwizard.Application<UltiCalConfig> {
         env.jersey().register(MailResource.class);
         env.jersey().register(ClubResource.class);
         env.jersey().register(ContextResource.class);
+
+        env.jersey().register(UlticalLoggingFilter.class);
 
         /*
          * Authentication stuff. Basically the authenticator looks up the

--- a/backend/src/main/java/de/ultical/backend/app/logging/UlticalLoggingFilter.java
+++ b/backend/src/main/java/de/ultical/backend/app/logging/UlticalLoggingFilter.java
@@ -1,0 +1,33 @@
+package de.ultical.backend.app.logging;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.Context;
+
+import org.slf4j.MDC;
+
+public class UlticalLoggingFilter implements ContainerRequestFilter, ContainerResponseFilter {
+
+    private static final String MDC_KEY_REMOTE_IP = "remoteIp";
+    @Context
+    HttpServletRequest servletReq;
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        MDC.put(MDC_KEY_REMOTE_IP, this.servletReq.getRemoteAddr());
+
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+            throws IOException {
+        MDC.remove(MDC_KEY_REMOTE_IP);
+
+    }
+
+}

--- a/backend/src/main/resources/default.yaml.dist
+++ b/backend/src/main/resources/default.yaml.dist
@@ -33,4 +33,22 @@ jobs:
 reCaptcha:
   url: https://www.google.com/recaptcha/api/siteverify
   secret: ...
-  
+
+
+logging:
+  level: INFO
+  appenders:
+    - type: file
+      currentLogFilename: ./logs/ultical.log
+      archive: true
+      archivedLogFilenamePattern: ./logs/ultical-%d.log.gz
+      archivedFileCount: 7
+      threshold: INFO
+      logFormat: %-5p [%d{ISO8601,CET}] %c{5}:%-15X{remoteIp} %m%n%rEx
+    - type: file
+      currentLogFilename: ./logs/ultical-err.log
+      archive: true
+      archivedLogFilenamePattern: ./logs/ultical-err-%d.log.gz
+      archivedFileCount: 14
+      threshold: ERROR
+      logFormat: %-5p [%d{ISO8601,CET}] %c{5}:%-15X{remoteIp} %m%n%rEx


### PR DESCRIPTION
added request- and response filters in order to set the MDC holding the remoteaddress for the current request. This could then be used in the logging patterns in order to group corresponding log statements
