### PR TITLE
DFV wishes to see directly which team a player belongs to

### DIFF
--- a/web/components/ultical_filters.js
+++ b/web/components/ultical_filters.js
@@ -236,7 +236,7 @@ app.filter('playername', [function () {
 		}
 
 		if (showClub && player.club != null) {
-			playername += ' (' + player.club.name + ')';
+			playername += '  (' + player.club.name + ')';
 		}
 		return playername;
 	};

--- a/web/pages/event/show.html
+++ b/web/pages/event/show.html
@@ -374,7 +374,7 @@
 																		<span ng-if="((event | isEmpty) || eventIsFuture) && regTeam.team.x.own">({{ 'event.rosterEditOnTeamPage' | translate }})</span>
 																	</div>
 																	<div class="margin-left-small" ng-if="rosterPlayers.length > 0 && loggedIn()">
-																		<div ng-repeat="rosterPlayer in rosterPlayers | orderBy : 'player.lastName'">{{ rosterPlayer.player | playername : true }}</div>
+																		<div ng-repeat="rosterPlayer in rosterPlayers | orderBy : 'player.lastName'">{{ rosterPlayer.player | playername : true : true }}</div>
 																	</div>
 																	<div ng-if="loggedIn() && rosterPlayers.length == 0">{{ 'team.roster.empty' | translate }}</div>
 																	<div ng-if="!loggedIn()">{{ 'team.roster.notLoggedIn' | translate }}</div>

--- a/web/pages/team/show.html
+++ b/web/pages/team/show.html
@@ -150,7 +150,7 @@
                     <div class="row">
                       <div class="col-md-12">
                         <div ng-if="loggedIn() && roster.players.length > 0" class="roster-list" ng-repeat="rosterPlayer in roster.players | orderBy : 'player.lastName'">
-                          {{ rosterPlayer.player | playername : true }}
+                          {{ rosterPlayer.player | playername : true : true }}
                           <small class="margin-left" ng-if="rosterPlayer.player.eligibleUntil">{{ 'team.roster.eligibleUntil' | translate }}&nbsp;{{ rosterPlayer.player.eligibleUntil | amDateFormat : ( 'general.amDateFormat' | translate ) }}</small>
                           <span ng-if="team.x.own && editingRosterPlayers == roster.id && !rosterPlayer.blocked" ng-click="removePlayerFromRoster(rosterPlayer.player, roster, team)" class="ffade player-actions cursor-pointer" data-title="{{ 'team.roster.removePlayerTooltip' | translate }}" bs-tooltip>
                             <i class="fa fa-remove"></i>


### PR DESCRIPTION
We are now showing the players' teams behind each name in the roster listing (both in team-view and event-view)